### PR TITLE
Automatically update reading group site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip" # caching pip dependencies
+      - name: Install Python Dependencies 📦
+        run: pip install jinja2
+      - name: Run Update Script 📝
+        run: python scripts/reading-group/update_reading_group_site.py
       - name: Update _config.yml ⚙️
         uses: fjogeleit/yaml-update-action@main
         with:

--- a/_config.yml
+++ b/_config.yml
@@ -186,6 +186,7 @@ exclude:
   - README.md
   - readme_preview/
   - vendor
+  - scripts
 keep_files:
   - CNAME
   - .nojekyll

--- a/scripts/reading-group/page_template.md
+++ b/scripts/reading-group/page_template.md
@@ -1,0 +1,110 @@
+---
+layout: default
+title: TRL reading group
+permalink: /trl-reading-group/
+nav: false
+collection: books
+---
+
+# ALOT - Amsterdam Lunch On Table
+
+## Description
+
+Amsterdam Lunch on Table (ALOT) is a **reading group focussed on table representation learning** and generally neural
+models for structured data that takes place on every first and third Wednesday of the month over lunch (at 12:00). Our
+objective is to foster a collaborative environment where researchers from the Amsterdam region can discuss and explore
+the intersection of AI and structured data. Each session is designed to be interactive, encouraging participants to
+engage in discussions that deepen their understanding of the latest research and methodologies. Through these sessions,
+we aim to inspire research ideas, support growth as researcher, and facilitate networking opportunities within the
+community.
+
+---
+
+<details open>
+<summary><strong>Where & when?</strong></summary>
+<ul>
+    <li><strong>When:</strong> Every first and third Wednesday of the month at 12:00 (over lunch)</li>
+    <li><strong>Where:</strong> For now, Centrum Wiskunde & Informatica (CWI), room L302 (Science Park 123, 1098 XG Amsterdam)</li>
+</ul>
+Please respond to our message on Discord if you are joining so we can pick you up at the CWI entrance. In the future,
+we plan to move the location to the UvA campus at Science Park to make it more accessible for everyone. We will keep you
+updated on this!
+</details>
+
+---
+
+<details>
+<summary><strong>How it works</strong></summary>
+We discuss one paper in each session. The paper is selected by the group and is announced at least a week in advance.
+One person is responsible for chairing the session and preparing a short introduction to the paper.
+The session chair is also responsible for facilitating the discussion and ensuring that everyone has a chance to
+contribute. We expect participants to read the paper in advance and send some questions or discussion points to the
+session chair to enable a more comprehensive and engaging discussion.<br>
+
+We are meeting for our reading group over lunch, and we encourage people to eat while we are discussing the paper. We
+have catered lunch for the group, so you don't have to bring your own lunch. Please indicate if you are coming to the
+session on the announcement on Discord so we can order enough food for everyone!
+
+</details>
+
+---
+
+**Want to join the reading group?** Then join the [ALOT Discord channel](https://discord.gg/fSgyRFqCDB). We manage
+the reading group via Discord and will announce the papers and sessions there.
+
+---
+
+## Next Session
+
+{% if upcoming_sessions %}
+The next session of the ALOT reading group will take place on **{{ upcoming_sessions[0].date.strftime('%A, %B %d, %Y at %H:%M') }}** and we will discuss:
+
+_**Paper:** [{{ upcoming_sessions[0].paper.title }}]({{ upcoming_sessions[0].paper.url }})_\
+_**Authors:** {{ format_authors(upcoming_sessions[0].paper) }}_\
+_**Venue:** {{ upcoming_sessions[0].paper.venue }} ({{ upcoming_sessions[0].paper.year }})_\
+_**Session Chair:** [{{ upcoming_sessions[0].chair }}]({{ upcoming_sessions[0].chair_email }})_
+
+<details>
+<summary>Abstract</summary>
+{{ upcoming_sessions[0].paper.abstract }}
+</details>
+
+
+{% if upcoming_sessions[0].notes %}
+_**Note:** {{ upcoming_sessions[0].notes }}_
+{% endif %}
+
+{% else %}
+_No upcoming sessions scheduled at the moment. Stay tuned for updates!_
+{% endif %}
+
+---
+
+## Previous Sessions
+
+{% if past_sessions %}
+{% for year, sessions_by_year in past_sessions | groupby('date.year') | reverse %}
+<details {% if year == current_year %}open{% endif %}>
+<summary><strong>{{ year }}</strong></summary>
+{% for session in sessions_by_year %}
+<details style="margin-left: 50px;">
+<summary><strong>{{ session.date.strftime('%A, %B %d, %Y') }} - {{ session.paper.title }}</strong></summary>
+<ul>
+    <li><strong>Title: </strong> <a href="{{ session.paper.url }}"> {{ session.paper.title }} </a> </li>
+    <li><strong>Authors:</strong> {{ format_authors(session.paper) }}</li>
+    <li><strong>Venue:</strong> {{ session.paper.venue }} ({{ session.paper.year }})</li>
+    <li><strong>Session Chair:</strong> <a href="mailto:{{ session.chair_email }}"> {{ session.chair }} </a></li>
+</ul>
+<p><strong>Abstract:</strong> {{ session.paper.abstract }}</p>
+{% if session.notes %}
+<p><strong>Notes:</strong> {{ session.notes }}</p>
+{% endif %}
+</details>
+{% endfor %}
+</details>
+<hr/>
+{% endfor %}
+{% else %}
+_No previous sessions yet. Check back after the first session!_
+{% endif %}
+

--- a/scripts/reading-group/sessions.json
+++ b/scripts/reading-group/sessions.json
@@ -1,0 +1,16 @@
+[
+    {
+        "date": "2025-04-16T12:00:00",
+        "paper": {
+            "title": "Large Language Models(LLMs) on Tabular Data: Prediction, Generation, and Understanding - A Survey",
+            "authors": ["X. Fang", "W. Xu", "F. Tan", "J. Zhang", "Z. Hu", "Y. Qi", "S. Nickleach", "D. Socolinsky", "S. Segengamedu", "C. Faloutsos"],
+            "url": "https://openreview.net/forum?id=IZnrCGF9WI",
+            "year": 2024,
+            "venue": "Transactions on Machine Learning Research",
+            "abstract":  "Recent breakthroughs in large language modeling have facilitated rigorous exploration of their application in diverse tasks related to tabular data modeling, such as prediction, tabular data synthesis, question answering, and table understanding. Each task presents unique challenges and opportunities. However, there is currently a lack of comprehensive review that summarizes and compares the key techniques, metrics, datasets, models, and optimization approaches in this research domain. This survey aims to address this gap by consolidating recent progress in these areas, offering a thorough survey and taxonomy of the datasets, metrics, and methodologies utilized. It identifies strengths, limitations, unexplored territories, and gaps in the existing literature, while providing some insights for future research directions in this vital and rapidly evolving field. It also provides relevant code and datasets references. Through this comprehensive review, we hope to provide interested readers with pertinent references and insightful perspectives, empowering them with the necessary tools and knowledge to effectively navigate and address the prevailing challenges in the field"
+        },
+        "chair": "Daniel Gomm",
+        "chair_email": "daniel.gomm@cwi.nl",
+        "notes": "We are reading this survey paper in our inaugural session to get a good overview of the field."
+    }
+]

--- a/scripts/reading-group/update_reading_group_site.py
+++ b/scripts/reading-group/update_reading_group_site.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+from datetime import datetime
+from jinja2 import Template
+from dataclasses import dataclass
+from typing import Optional, List
+
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+@dataclass
+class Paper:
+    """A paper in the reading group."""
+    title: str
+    authors: List[str]
+    url: str
+    year: int
+    venue: str
+    abstract: str
+
+    def formatted_authors(self) -> str:
+        """Format authors list to show 'First Author et al.' if there are more than two authors."""
+        if len(self.authors) > 2:
+            return f"{self.authors[0]} et al."
+        return ", ".join(self.authors)
+
+@dataclass
+class ReadingGroupSession:
+    """A reading group session."""
+    date: datetime
+    paper: Paper
+    chair: str
+    chair_email: str
+    notes: Optional[str] = None
+
+def load_sessions(json_path: str) -> List[ReadingGroupSession]:
+    with open(json_path, 'r') as f:
+        sessions_data = json.load(f)
+    return [
+        ReadingGroupSession(
+            date=datetime.strptime(session['date'], DATE_FORMAT),
+            paper=Paper(**session['paper']),
+            chair=session['chair'],
+            chair_email=session['chair_email'],
+            notes=session.get('notes')
+        )
+        for session in sessions_data
+    ]
+
+def generate_markdown(template_path: str, sessions: List[ReadingGroupSession]):
+    # Sort sessions by date
+    sessions.sort(key=lambda s: s.date)
+    upcoming_sessions = [s for s in sessions if s.date >= datetime.now()]
+    past_sessions = [s for s in sessions if s.date < datetime.now()]
+
+    # Load template
+    with open(template_path, 'r') as f:
+        template = Template(f.read())
+
+    # Render template
+    rendered_content = template.render(
+        upcoming_sessions=upcoming_sessions,
+        past_sessions=past_sessions,
+        format_authors=lambda paper: paper.formatted_authors(),  # Pass helper function to template
+        current_year=datetime.now().year
+    )
+
+    # Save output
+    output_file = Path("_pages/trl-reading-group.md")
+    with open(output_file, 'w') as f:
+        f.write(rendered_content)
+
+if __name__ == "__main__":
+    sessions = load_sessions("scripts/reading-group/sessions.json")
+    generate_markdown(
+        template_path="scripts/reading-group/page_template.md",
+        sessions=sessions
+    )


### PR DESCRIPTION
Allows to update the reading group page by modifying the sessions.json file - streamlining the management of the reading group page.

The PR adds:
- A jinja template for the reading group site
- A collection of reading group session information (sessions.json)
- A script for automatically generating the reading group page from the template and the session information
- Automatic execution of the script by the github action for deploying the site -> only the session.json has to be update, the rest will be automatically handled by the github action 